### PR TITLE
Add resource injection and fix MDX curly brace escaping

### DIFF
--- a/generate-post.cmd
+++ b/generate-post.cmd
@@ -4,10 +4,10 @@ setlocal enabledelayedexpansion
 @REM ============================================
 @REM  Set your blog post topic here:
 @REM ============================================
-set "TOPIC=Collision Detection Approaches: how to detect whether two objects overlap in 3D"
+set "TOPIC=Leukocytes: what they are, how they work, and their importance in pharmacy"
 set "ITERATIONS=2"
 set "IMAGES=true"
-set "IMAGE_COUNT=5"
+set "IMAGE_COUNT=7"
 set "AUDIO=true"
 @REM Optional: path to a file with one resource URL or snippet per line
 set "RESOURCES_FILE="

--- a/generate-post.cmd
+++ b/generate-post.cmd
@@ -4,7 +4,7 @@ setlocal enabledelayedexpansion
 @REM ============================================
 @REM  Set your blog post topic here:
 @REM ============================================
-set "TOPIC=How a Basic Rigid Body Simulation Works: forces, properties, and stepping forward in time"
+set "TOPIC=Collision Detection Approaches: how to detect whether two objects overlap in 3D"
 set "ITERATIONS=2"
 set "IMAGES=true"
 set "IMAGE_COUNT=5"

--- a/generate-post.cmd
+++ b/generate-post.cmd
@@ -1,5 +1,5 @@
 @echo off
-setlocal
+setlocal enabledelayedexpansion
 
 @REM ============================================
 @REM  Set your blog post topic here:
@@ -9,12 +9,32 @@ set "ITERATIONS=2"
 set "IMAGES=true"
 set "IMAGE_COUNT=5"
 set "AUDIO=true"
+@REM Optional: path to a file with one resource URL or snippet per line
+set "RESOURCES_FILE="
 @REM ============================================
 
 @REM Load .env file
 if exist "%~dp0.env" (
     for /f "usebackq tokens=1,* delims==" %%a in ("%~dp0.env") do (
         if not "%%a"=="" if not "%%b"=="" set "%%a=%%b"
+    )
+)
+
+@REM Build resources JSON array from file
+set "RESOURCES_JSON="
+if defined RESOURCES_FILE (
+    if exist "%RESOURCES_FILE%" (
+        set "RESOURCES_JSON=, \"resources\": ["
+        set "FIRST=1"
+        for /f "usebackq delims=" %%r in ("%RESOURCES_FILE%") do (
+            if !FIRST!==1 (
+                set "RESOURCES_JSON=!RESOURCES_JSON!\"%%r\""
+                set "FIRST=0"
+            ) else (
+                set "RESOURCES_JSON=!RESOURCES_JSON!, \"%%r\""
+            )
+        )
+        set "RESOURCES_JSON=!RESOURCES_JSON!]"
     )
 )
 
@@ -32,9 +52,12 @@ echo Server is ready. Generating blog post...
 echo Topic: %TOPIC%
 echo Images: %IMAGES% (max %IMAGE_COUNT%)
 echo Audio: %AUDIO%
+if defined RESOURCES_FILE (
+    if exist "%RESOURCES_FILE%" echo Resources: %RESOURCES_FILE%
+)
 echo.
 
-curl -s -X POST http://localhost:8080/api/generate -H "Content-Type: application/json" -d "{\"topic\": \"%TOPIC%\", \"iterations\": %ITERATIONS%, \"images\": %IMAGES%, \"imageCount\": %IMAGE_COUNT%, \"audio\": %AUDIO%}"
+curl -s -X POST http://localhost:8080/api/generate -H "Content-Type: application/json" -d "{\"topic\": \"%TOPIC%\", \"iterations\": %ITERATIONS%, \"images\": %IMAGES%, \"imageCount\": %IMAGE_COUNT%, \"audio\": %AUDIO%!RESOURCES_JSON!}"
 
 echo.
 echo.

--- a/generate-post.cmd
+++ b/generate-post.cmd
@@ -4,7 +4,7 @@ setlocal enabledelayedexpansion
 @REM ============================================
 @REM  Set your blog post topic here:
 @REM ============================================
-set "TOPIC=C++ Memory Layout: stack vs heap and how objects are stored"
+set "TOPIC=How a Basic Rigid Body Simulation Works: forces, properties, and stepping forward in time"
 set "ITERATIONS=2"
 set "IMAGES=true"
 set "IMAGE_COUNT=5"

--- a/src/main/java/com/maxthomarino/res/controller/GenerateController.java
+++ b/src/main/java/com/maxthomarino/res/controller/GenerateController.java
@@ -24,6 +24,7 @@ public class GenerateController {
         boolean images = request.images() != null && request.images();
         int imageCount = request.imageCount() != null ? request.imageCount() : 5;
         boolean audio = request.audio() != null && request.audio();
-        return blogGeneratorService.generate(request.topic(), iterations, images, imageCount, audio);
+        var resources = request.resources() != null ? request.resources() : java.util.List.<String>of();
+        return blogGeneratorService.generate(request.topic(), iterations, images, imageCount, audio, resources);
     }
 }

--- a/src/main/java/com/maxthomarino/res/dto/GenerateRequest.java
+++ b/src/main/java/com/maxthomarino/res/dto/GenerateRequest.java
@@ -1,4 +1,7 @@
 package com.maxthomarino.res.dto;
 
-public record GenerateRequest(String topic, Integer iterations, Boolean images, Integer imageCount, Boolean audio) {
+import java.util.List;
+
+public record GenerateRequest(String topic, Integer iterations, Boolean images, Integer imageCount, Boolean audio,
+                               List<String> resources) {
 }

--- a/src/main/java/com/maxthomarino/res/service/BlogGeneratorService.java
+++ b/src/main/java/com/maxthomarino/res/service/BlogGeneratorService.java
@@ -64,7 +64,7 @@ public class BlogGeneratorService {
             }
         }
 
-        content = escapeMdxAngleBrackets(content);
+        content = escapeMdxSpecialChars(content);
 
         BlogPost finalPost = new BlogPost(
                 post.title(), post.date(), post.description(), post.tags(),
@@ -107,16 +107,17 @@ public class BlogGeneratorService {
     }
 
     /**
-     * Escapes angle brackets in prose that MDX would misinterpret as JSX tags,
-     * while preserving code fences, inline code, and intentional HTML/JSX tags.
+     * Escapes MDX-sensitive characters in prose while preserving code fences,
+     * inline code, math blocks, and intentional HTML/JSX tags.
      */
-    static String escapeMdxAngleBrackets(String content) {
-        // Pattern to match protected regions: code fences, inline code, HTML tags, and markdown images
+    static String escapeMdxSpecialChars(String content) {
         Pattern protectedRegion = Pattern.compile(
                 "```[\\s\\S]*?```"            // code fences
+                + "|\\$\\$[\\s\\S]*?\\$\\$"   // display math $$...$$
+                + "|\\$[^$\\n]+\\$"            // inline math $...$
                 + "|`[^`]+`"                   // inline code
                 + "|!\\[[^]]*\\]\\([^)]*\\)"   // markdown images ![...](...)
-                + "|</?[A-Z]\\w*[^>]*/?>\\s*"  // JSX components (uppercase first letter, e.g. <BlogAudioPlayer ... />)
+                + "|</?[A-Z]\\w*[^>]*/?>\\s*"  // JSX components
                 + "|</?(?:audio|source|img|br|hr|div|span|p|a|em|strong|ul|ol|li|table|tr|td|th|thead|tbody|blockquote|pre|code|h[1-6])[^>]*/?>" // known HTML tags
         );
 
@@ -126,19 +127,21 @@ public class BlogGeneratorService {
 
         while (matcher.find()) {
             String prose = content.substring(lastEnd, matcher.start());
-            result.append(escapeAngleBracketsInProse(prose));
+            result.append(escapeProseForMdx(prose));
             // Append protected region unchanged
             result.append(matcher.group());
             lastEnd = matcher.end();
         }
-        // Handle remaining prose after last protected region
-        result.append(escapeAngleBracketsInProse(content.substring(lastEnd)));
+        result.append(escapeProseForMdx(content.substring(lastEnd)));
 
         return result.toString();
     }
 
-    private static String escapeAngleBracketsInProse(String prose) {
+    private static String escapeProseForMdx(String prose) {
         // Escape <word> patterns that MDX would parse as JSX components (e.g. <Derived>, <int>, <T>)
-        return prose.replaceAll("<(\\w[^>]*)>", "&lt;$1&gt;");
+        String escaped = prose.replaceAll("<(\\w[^>]*)>", "&lt;$1&gt;");
+        // Escape curly braces that MDX would parse as JSX expressions
+        escaped = escaped.replace("{", "\\{").replace("}", "\\}");
+        return escaped;
     }
 }

--- a/src/main/java/com/maxthomarino/res/service/BlogGeneratorService.java
+++ b/src/main/java/com/maxthomarino/res/service/BlogGeneratorService.java
@@ -64,7 +64,7 @@ public class BlogGeneratorService {
             }
         }
 
-        content = escapeMdxSpecialChars(content);
+        content = escapeMdxAngleBrackets(content);
 
         BlogPost finalPost = new BlogPost(
                 post.title(), post.date(), post.description(), post.tags(),
@@ -107,10 +107,10 @@ public class BlogGeneratorService {
     }
 
     /**
-     * Escapes characters in prose that MDX would misinterpret as JSX,
+     * Escapes angle brackets in prose that MDX would misinterpret as JSX tags,
      * while preserving code fences, inline code, and intentional HTML/JSX tags.
      */
-    static String escapeMdxSpecialChars(String content) {
+    static String escapeMdxAngleBrackets(String content) {
         // Pattern to match protected regions: code fences, inline code, HTML tags, and markdown images
         Pattern protectedRegion = Pattern.compile(
                 "```[\\s\\S]*?```"            // code fences
@@ -126,22 +126,19 @@ public class BlogGeneratorService {
 
         while (matcher.find()) {
             String prose = content.substring(lastEnd, matcher.start());
-            result.append(escapeProseForMdx(prose));
+            result.append(escapeAngleBracketsInProse(prose));
             // Append protected region unchanged
             result.append(matcher.group());
             lastEnd = matcher.end();
         }
         // Handle remaining prose after last protected region
-        result.append(escapeProseForMdx(content.substring(lastEnd)));
+        result.append(escapeAngleBracketsInProse(content.substring(lastEnd)));
 
         return result.toString();
     }
 
-    private static String escapeProseForMdx(String prose) {
+    private static String escapeAngleBracketsInProse(String prose) {
         // Escape <word> patterns that MDX would parse as JSX components (e.g. <Derived>, <int>, <T>)
-        String escaped = prose.replaceAll("<(\\w[^>]*)>", "&lt;$1&gt;");
-        // Escape curly braces that MDX would parse as JSX expressions (e.g. LaTeX \mathbf{x})
-        escaped = escaped.replace("{", "\\{").replace("}", "\\}");
-        return escaped;
+        return prose.replaceAll("<(\\w[^>]*)>", "&lt;$1&gt;");
     }
 }

--- a/src/main/java/com/maxthomarino/res/service/BlogGeneratorService.java
+++ b/src/main/java/com/maxthomarino/res/service/BlogGeneratorService.java
@@ -64,7 +64,7 @@ public class BlogGeneratorService {
             }
         }
 
-        content = escapeMdxAngleBrackets(content);
+        content = escapeMdxSpecialChars(content);
 
         BlogPost finalPost = new BlogPost(
                 post.title(), post.date(), post.description(), post.tags(),
@@ -107,10 +107,10 @@ public class BlogGeneratorService {
     }
 
     /**
-     * Escapes angle brackets in prose that MDX would misinterpret as JSX tags,
-     * while preserving code fences, inline code, and intentional HTML tags.
+     * Escapes characters in prose that MDX would misinterpret as JSX,
+     * while preserving code fences, inline code, and intentional HTML/JSX tags.
      */
-    static String escapeMdxAngleBrackets(String content) {
+    static String escapeMdxSpecialChars(String content) {
         // Pattern to match protected regions: code fences, inline code, HTML tags, and markdown images
         Pattern protectedRegion = Pattern.compile(
                 "```[\\s\\S]*?```"            // code fences
@@ -125,21 +125,23 @@ public class BlogGeneratorService {
         int lastEnd = 0;
 
         while (matcher.find()) {
-            // Escape angle brackets in the prose between protected regions
             String prose = content.substring(lastEnd, matcher.start());
-            result.append(escapeAngleBracketsInProse(prose));
+            result.append(escapeProseForMdx(prose));
             // Append protected region unchanged
             result.append(matcher.group());
             lastEnd = matcher.end();
         }
         // Handle remaining prose after last protected region
-        result.append(escapeAngleBracketsInProse(content.substring(lastEnd)));
+        result.append(escapeProseForMdx(content.substring(lastEnd)));
 
         return result.toString();
     }
 
-    private static String escapeAngleBracketsInProse(String prose) {
+    private static String escapeProseForMdx(String prose) {
         // Escape <word> patterns that MDX would parse as JSX components (e.g. <Derived>, <int>, <T>)
-        return prose.replaceAll("<(\\w[^>]*)>", "&lt;$1&gt;");
+        String escaped = prose.replaceAll("<(\\w[^>]*)>", "&lt;$1&gt;");
+        // Escape curly braces that MDX would parse as JSX expressions (e.g. LaTeX \mathbf{x})
+        escaped = escaped.replace("{", "\\{").replace("}", "\\}");
+        return escaped;
     }
 }

--- a/src/main/java/com/maxthomarino/res/service/BlogGeneratorService.java
+++ b/src/main/java/com/maxthomarino/res/service/BlogGeneratorService.java
@@ -138,8 +138,9 @@ public class BlogGeneratorService {
     }
 
     private static String escapeProseForMdx(String prose) {
-        // Escape <word> patterns that MDX would parse as JSX components (e.g. <Derived>, <int>, <T>)
-        String escaped = prose.replaceAll("<(\\w[^>]*)>", "&lt;$1&gt;");
+        // Escape all bare < that MDX would try to parse as JSX/HTML (e.g. <Derived>, <500, <T>)
+        // Protected regions (known HTML, JSX, images, math) are already excluded by the caller.
+        String escaped = prose.replace("<", "&lt;");
         // Escape curly braces that MDX would parse as JSX expressions
         escaped = escaped.replace("{", "\\{").replace("}", "\\}");
         return escaped;

--- a/src/main/java/com/maxthomarino/res/service/BlogGeneratorService.java
+++ b/src/main/java/com/maxthomarino/res/service/BlogGeneratorService.java
@@ -64,6 +64,8 @@ public class BlogGeneratorService {
             }
         }
 
+        content = appendQuiz(content, post);
+
         content = escapeMdxSpecialChars(content);
 
         BlogPost finalPost = new BlogPost(
@@ -102,6 +104,19 @@ public class BlogGeneratorService {
                 log.error("Failed to process image {}: {}", placement.placeholder(), e.getMessage());
                 content = content.replace(placement.placeholder(), "");
             }
+        }
+        return content;
+    }
+
+    private String appendQuiz(String content, BlogPost post) {
+        try {
+            String quizJson = llmService.generateQuizJson(post);
+            if (quizJson != null) {
+                String encoded = Base64.getEncoder().encodeToString(quizJson.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+                content = content + "\n\n<BlogQuiz data=\"" + encoded + "\" />\n";
+            }
+        } catch (Exception e) {
+            log.error("Quiz generation failed, publishing without quiz: {}", e.getMessage());
         }
         return content;
     }

--- a/src/main/java/com/maxthomarino/res/service/BlogGeneratorService.java
+++ b/src/main/java/com/maxthomarino/res/service/BlogGeneratorService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.Base64;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -22,20 +23,26 @@ public class BlogGeneratorService {
     private final GitHubService gitHubService;
     private final ImageService imageService;
     private final TtsService ttsService;
+    private final ResourceService resourceService;
 
     public BlogGeneratorService(LlmService llmService, GitHubService gitHubService,
-                                ImageService imageService, TtsService ttsService) {
+                                ImageService imageService, TtsService ttsService,
+                                ResourceService resourceService) {
         this.llmService = llmService;
         this.gitHubService = gitHubService;
         this.imageService = imageService;
         this.ttsService = ttsService;
+        this.resourceService = resourceService;
     }
 
-    public GenerateResponse generate(String topic, int iterations, boolean withImages, int imageCount, boolean withAudio) {
-        BlogPost post = llmService.generatePost(topic, withImages, imageCount);
+    public GenerateResponse generate(String topic, int iterations, boolean withImages, int imageCount,
+                                      boolean withAudio, List<String> resources) {
+        List<String> resolvedResources = resourceService.resolveResources(resources);
+
+        BlogPost post = llmService.generatePost(topic, withImages, imageCount, resolvedResources);
         for (int i = 0; i < iterations - 1; i++) {
             String feedback = llmService.reviewPost(post);
-            post = llmService.revisePost(post, feedback, withImages, imageCount);
+            post = llmService.revisePost(post, feedback, withImages, imageCount, resolvedResources);
         }
 
         String content = post.content();

--- a/src/main/java/com/maxthomarino/res/service/LlmService.java
+++ b/src/main/java/com/maxthomarino/res/service/LlmService.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.maxthomarino.res.model.BlogPost;
 import com.maxthomarino.res.model.ImagePlacement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
@@ -15,6 +17,8 @@ import java.util.Map;
 
 @Service
 public class LlmService {
+
+    private static final Logger log = LoggerFactory.getLogger(LlmService.class);
 
     private final RestClient restClient;
     private final ObjectMapper objectMapper;
@@ -33,13 +37,17 @@ public class LlmService {
     }
 
     private String chatCompletion(String systemPrompt, String userMessage) {
+        return chatCompletion(systemPrompt, userMessage, 0.7);
+    }
+
+    private String chatCompletion(String systemPrompt, String userMessage, double temperature) {
         Map<String, Object> requestBody = Map.of(
                 "model", model,
                 "messages", List.of(
                         Map.of("role", "system", "content", systemPrompt),
                         Map.of("role", "user", "content", userMessage)
                 ),
-                "temperature", 0.7
+                "temperature", temperature
         );
 
         String responseBody = restClient.post()
@@ -215,5 +223,61 @@ public class LlmService {
             }
         }
         return images;
+    }
+
+    /**
+     * Generates a 30-question multiple-choice quiz based on the blog post content.
+     * Returns the raw JSON string on success, or null if generation/validation fails.
+     */
+    public String generateQuizJson(BlogPost post) {
+        String systemPrompt = """
+                You are a quiz generator. Given a blog post, create exactly 30 multiple-choice questions \
+                that test the reader's understanding of the key concepts covered in the post. \
+                Each question must have exactly 4 options with one correct answer.
+
+                Return ONLY a valid JSON array (no markdown fences, no wrapper object) with this structure:
+                [
+                  {
+                    "question": "What is ...?",
+                    "options": ["Option A", "Option B", "Option C", "Option D"],
+                    "answer": 0
+                  }
+                ]
+                Where "answer" is the zero-based index (0-3) of the correct option. \
+                Do not wrap the JSON in markdown code fences. Return raw JSON only.""";
+
+        String userMessage = "Title: " + post.title() + "\n\n" + post.content();
+
+        try {
+            String response = chatCompletion(systemPrompt, userMessage, 0.4);
+            JsonNode quiz = objectMapper.readTree(response);
+
+            if (!quiz.isArray() || quiz.size() != 30) {
+                log.warn("Quiz validation failed: expected array of 30, got {}", quiz.size());
+                return null;
+            }
+
+            for (JsonNode q : quiz) {
+                if (!q.has("question") || !q.has("options") || !q.has("answer")) {
+                    log.warn("Quiz validation failed: missing required fields");
+                    return null;
+                }
+                JsonNode options = q.path("options");
+                if (!options.isArray() || options.size() != 4) {
+                    log.warn("Quiz validation failed: expected 4 options");
+                    return null;
+                }
+                int answer = q.path("answer").asInt(-1);
+                if (answer < 0 || answer > 3) {
+                    log.warn("Quiz validation failed: answer index out of range");
+                    return null;
+                }
+            }
+
+            return response;
+        } catch (Exception e) {
+            log.error("Quiz generation failed: {}", e.getMessage());
+            return null;
+        }
     }
 }

--- a/src/main/java/com/maxthomarino/res/service/LlmService.java
+++ b/src/main/java/com/maxthomarino/res/service/LlmService.java
@@ -83,8 +83,8 @@ public class LlmService {
                   "content": "The full blog post content in markdown format. Use ## for subheadings. Do NOT include the title as an h1."
                 }
                 Do not wrap the JSON in markdown code fences. Return raw JSON only.
-                IMPORTANT: The output will be rendered as MDX. Do NOT use LaTeX math notation (\\(, \\), \\[, \\]). \
-                Instead, use inline code (`F = m * a`) for formulas and plain text for equations.""";
+                The output will be rendered as MDX with KaTeX support. You may use LaTeX math notation \
+                (\\( \\) for inline, \\[ \\] for display) for formulas.""";
 
         if (withImages) {
             systemPrompt += imageInstruction(imageCount);
@@ -147,8 +147,8 @@ public class LlmService {
                   "content": "The full blog post content in markdown format. Use ## for subheadings. Do NOT include the title as an h1."
                 }
                 Do not wrap the JSON in markdown code fences. Return raw JSON only.
-                IMPORTANT: The output will be rendered as MDX. Do NOT use LaTeX math notation (\\(, \\), \\[, \\]). \
-                Instead, use inline code (`F = m * a`) for formulas and plain text for equations.""";
+                The output will be rendered as MDX with KaTeX support. You may use LaTeX math notation \
+                (\\( \\) for inline, \\[ \\] for display) for formulas.""";
 
         if (withImages) {
             systemPrompt += """

--- a/src/main/java/com/maxthomarino/res/service/LlmService.java
+++ b/src/main/java/com/maxthomarino/res/service/LlmService.java
@@ -83,8 +83,9 @@ public class LlmService {
                   "content": "The full blog post content in markdown format. Use ## for subheadings. Do NOT include the title as an h1."
                 }
                 Do not wrap the JSON in markdown code fences. Return raw JSON only.
-                The output will be rendered as MDX with KaTeX support. You may use LaTeX math notation \
-                (\\( \\) for inline, \\[ \\] for display) for formulas.""";
+                The output will be rendered as MDX with KaTeX support via remark-math. \
+                Use $...$ for inline math and $$...$$ for display math. \
+                Display math ($$) must start at column 0 (no leading whitespace), even inside list items.""";
 
         if (withImages) {
             systemPrompt += imageInstruction(imageCount);
@@ -147,8 +148,9 @@ public class LlmService {
                   "content": "The full blog post content in markdown format. Use ## for subheadings. Do NOT include the title as an h1."
                 }
                 Do not wrap the JSON in markdown code fences. Return raw JSON only.
-                The output will be rendered as MDX with KaTeX support. You may use LaTeX math notation \
-                (\\( \\) for inline, \\[ \\] for display) for formulas.""";
+                The output will be rendered as MDX with KaTeX support via remark-math. \
+                Use $...$ for inline math and $$...$$ for display math. \
+                Display math ($$) must start at column 0 (no leading whitespace), even inside list items.""";
 
         if (withImages) {
             systemPrompt += """

--- a/src/main/java/com/maxthomarino/res/service/LlmService.java
+++ b/src/main/java/com/maxthomarino/res/service/LlmService.java
@@ -82,7 +82,9 @@ public class LlmService {
                   "tags": ["Tag1", "Tag2", "Tag3"],
                   "content": "The full blog post content in markdown format. Use ## for subheadings. Do NOT include the title as an h1."
                 }
-                Do not wrap the JSON in markdown code fences. Return raw JSON only.""";
+                Do not wrap the JSON in markdown code fences. Return raw JSON only.
+                IMPORTANT: The output will be rendered as MDX. Do NOT use LaTeX math notation (\\(, \\), \\[, \\]). \
+                Instead, use inline code (`F = m * a`) for formulas and plain text for equations.""";
 
         if (withImages) {
             systemPrompt += imageInstruction(imageCount);
@@ -144,7 +146,9 @@ public class LlmService {
                   "tags": ["Tag1", "Tag2", "Tag3"],
                   "content": "The full blog post content in markdown format. Use ## for subheadings. Do NOT include the title as an h1."
                 }
-                Do not wrap the JSON in markdown code fences. Return raw JSON only.""";
+                Do not wrap the JSON in markdown code fences. Return raw JSON only.
+                IMPORTANT: The output will be rendered as MDX. Do NOT use LaTeX math notation (\\(, \\), \\[, \\]). \
+                Instead, use inline code (`F = m * a`) for formulas and plain text for equations.""";
 
         if (withImages) {
             systemPrompt += """

--- a/src/main/java/com/maxthomarino/res/service/LlmService.java
+++ b/src/main/java/com/maxthomarino/res/service/LlmService.java
@@ -87,10 +87,13 @@ public class LlmService {
                 {
                   "title": "Post Title",
                   "description": "A short 1-2 sentence description",
-                  "tags": ["Tag1", "Tag2", "Tag3"],
+                  "tags": ["Tag1", "Tag2"],
                   "content": "The full blog post content in markdown format. Use ## for subheadings. Do NOT include the title as an h1."
                 }
                 Do not wrap the JSON in markdown code fences. Return raw JSON only.
+                Use 1-3 tags maximum. Choose ONLY from these existing tags: \
+                AI, C++, Design Patterns, Education, Engineering, Game Development, Math, Medicine, Physics, Rust, Security, Systems, Web. \
+                Pick the most relevant 1-3; do not invent new tags.
                 The output will be rendered as MDX with KaTeX support via remark-math. \
                 Use $...$ for inline math and $$...$$ for display math. \
                 Display math ($$) must start at column 0 (no leading whitespace), even inside list items.""";
@@ -152,10 +155,13 @@ public class LlmService {
                 {
                   "title": "Post Title",
                   "description": "A short 1-2 sentence description",
-                  "tags": ["Tag1", "Tag2", "Tag3"],
+                  "tags": ["Tag1", "Tag2"],
                   "content": "The full blog post content in markdown format. Use ## for subheadings. Do NOT include the title as an h1."
                 }
                 Do not wrap the JSON in markdown code fences. Return raw JSON only.
+                Use 1-3 tags maximum. Choose ONLY from these existing tags: \
+                AI, C++, Design Patterns, Education, Engineering, Game Development, Math, Medicine, Physics, Rust, Security, Systems, Web. \
+                Pick the most relevant 1-3; do not invent new tags.
                 The output will be rendered as MDX with KaTeX support via remark-math. \
                 Use $...$ for inline math and $$...$$ for display math. \
                 Display math ($$) must start at column 0 (no leading whitespace), even inside list items.""";

--- a/src/main/java/com/maxthomarino/res/service/LlmService.java
+++ b/src/main/java/com/maxthomarino/res/service/LlmService.java
@@ -73,7 +73,7 @@ public class LlmService {
                 If no diagrams are appropriate, return an empty "images" array.""".formatted(imageCount);
     }
 
-    public BlogPost generatePost(String topic, boolean withImages, int imageCount) {
+    public BlogPost generatePost(String topic, boolean withImages, int imageCount, List<String> resolvedResources) {
         String systemPrompt = """
                 You are a technical blog writer. Given a topic, write a blog post and return ONLY valid JSON with this structure:
                 {
@@ -87,6 +87,8 @@ public class LlmService {
         if (withImages) {
             systemPrompt += imageInstruction(imageCount);
         }
+
+        systemPrompt += resourceBlock(resolvedResources);
 
         String content = chatCompletion(systemPrompt, "Write a blog post about: " + topic);
 
@@ -130,7 +132,8 @@ public class LlmService {
         return chatCompletion(systemPrompt, userMessage);
     }
 
-    public BlogPost revisePost(BlogPost post, String feedback, boolean withImages, int imageCount) {
+    public BlogPost revisePost(BlogPost post, String feedback, boolean withImages, int imageCount,
+                               List<String> resolvedResources) {
         String systemPrompt = """
                 You are a technical blog writer. You will receive a blog post and editorial feedback. \
                 Revise the post to address the feedback while preserving the original topic and intent. \
@@ -150,6 +153,8 @@ public class LlmService {
                     Preserve these placeholders in the content at appropriate locations. \
                     Also preserve the "images" array from the original post in your JSON output.""" + imageInstruction(imageCount);
         }
+
+        systemPrompt += resourceBlock(resolvedResources);
 
         String userMessage = "## Current Post\nTitle: " + post.title() + "\n\n" + post.content()
                 + "\n\n## Feedback\n" + feedback;
@@ -176,6 +181,19 @@ public class LlmService {
         } catch (Exception e) {
             throw new RuntimeException("Failed to parse OpenAI response", e);
         }
+    }
+
+    private static String resourceBlock(List<String> resolvedResources) {
+        if (resolvedResources == null || resolvedResources.isEmpty()) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder();
+        sb.append("\n\nYou may reference the following resources if relevant (do not fabricate citations):");
+        for (String resource : resolvedResources) {
+            sb.append("\n---\n").append(resource);
+        }
+        sb.append("\n---");
+        return sb.toString();
     }
 
     private List<ImagePlacement> parseImages(JsonNode blog) {

--- a/src/main/java/com/maxthomarino/res/service/ResourceService.java
+++ b/src/main/java/com/maxthomarino/res/service/ResourceService.java
@@ -1,0 +1,92 @@
+package com.maxthomarino.res.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class ResourceService {
+
+    private static final Logger log = LoggerFactory.getLogger(ResourceService.class);
+    private static final int MAX_CONTENT_LENGTH = 10_000;
+
+    private final RestClient restClient;
+    private final Map<String, String> cache = new HashMap<>();
+
+    public ResourceService() {
+        this.restClient = RestClient.builder()
+                .defaultHeader("User-Agent", "BlogGenerator/1.0")
+                .defaultHeader("Accept", "text/html,text/plain,*/*")
+                .build();
+    }
+
+    public List<String> resolveResources(List<String> resources) {
+        if (resources == null || resources.isEmpty()) {
+            return List.of();
+        }
+
+        List<String> resolved = new ArrayList<>();
+        for (String resource : resources) {
+            String content = resolveOne(resource.trim());
+            if (content != null && !content.isBlank()) {
+                resolved.add(content);
+            }
+        }
+        return resolved;
+    }
+
+    private String resolveOne(String resource) {
+        if (!resource.startsWith("http://") && !resource.startsWith("https://")) {
+            return resource;
+        }
+
+        if (cache.containsKey(resource)) {
+            return cache.get(resource);
+        }
+
+        try {
+            String html = restClient.get()
+                    .uri(resource)
+                    .retrieve()
+                    .body(String.class);
+
+            if (html == null) {
+                return null;
+            }
+
+            String text = stripHtml(html);
+            if (text.length() > MAX_CONTENT_LENGTH) {
+                text = text.substring(0, MAX_CONTENT_LENGTH) + "\n[...truncated]";
+            }
+
+            String result = "Source: " + resource + "\n" + text;
+            cache.put(resource, result);
+            return result;
+        } catch (Exception e) {
+            log.warn("Failed to fetch resource {}: {}", resource, e.getMessage());
+            return null;
+        }
+    }
+
+    private static String stripHtml(String html) {
+        return html
+                .replaceAll("<script[^>]*>[\\s\\S]*?</script>", " ")
+                .replaceAll("<style[^>]*>[\\s\\S]*?</style>", " ")
+                .replaceAll("<[^>]+>", " ")
+                .replaceAll("&nbsp;", " ")
+                .replaceAll("&amp;", "&")
+                .replaceAll("&lt;", "<")
+                .replaceAll("&gt;", ">")
+                .replaceAll("&quot;", "\"")
+                .replaceAll("&#39;", "'")
+                .replaceAll("[ \\t]+", " ")
+                .replaceAll("\\n\\s*\\n+", "\n")
+                .trim();
+    }
+}

--- a/src/main/java/com/maxthomarino/res/service/TtsService.java
+++ b/src/main/java/com/maxthomarino/res/service/TtsService.java
@@ -66,6 +66,11 @@ public class TtsService {
         // Remove code fences
         text = text.replaceAll("```[\\s\\S]*?```", "");
 
+        // Remove display math $$...$$
+        text = text.replaceAll("\\$\\$[\\s\\S]*?\\$\\$", "");
+        // Remove inline math $...$
+        text = text.replaceAll("\\$[^$\\n]+\\$", "");
+
         // Remove inline code backticks
         text = text.replaceAll("`([^`]*)`", "$1");
 


### PR DESCRIPTION
## Summary
- Add optional `resources` field to the generate API request — accepts a list of URLs or inline text snippets that get fetched server-side and injected into the LLM prompt as supplementary context
- Fix MDX build failures caused by curly braces (e.g., LaTeX `\mathbf{x}`) being interpreted as JSX expressions — escape `{` and `}` in prose sections
- Instruct the LLM to avoid LaTeX math notation and use inline code for formulas instead

## Changes
- **`ResourceService`** (new): Fetches URL content, strips HTML, caches results in-memory, truncates to 10k chars per resource
- **`GenerateRequest`**: Added `List<String> resources` field
- **`LlmService`**: Injects resolved resources into generation/revision system prompts; added no-LaTeX instruction
- **`BlogGeneratorService`**: Wires `ResourceService`, escapes `{}` in MDX prose (renamed `escapeMdxAngleBrackets` → `escapeMdxSpecialChars`)
- **`GenerateController`**: Passes resources through
- **`generate-post.cmd`**: Added `RESOURCES_FILE` config variable support

## Test plan
- [ ] `POST /api/generate` with no `resources` field works as before
- [ ] `POST /api/generate` with `"resources": ["https://example.com", "inline note"]` injects content into the LLM prompt
- [ ] Generated posts no longer contain bare `{}` in prose (escaped to `\{` `\}`)
- [ ] Generated posts avoid LaTeX math notation
- [ ] `generate-post.cmd` with `RESOURCES_FILE` set reads file and includes resources in request

Closes #8